### PR TITLE
Report player count in activity status message

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -75,13 +75,14 @@ const main = async () => {
 					state: 'Waiting for players',
 					timestamp: {
 						start: activityStart,
-						end: Date.now() + 11000
+						end: Date.now() + 11000,
 					},
 					party: {
-						size: [current, max]
-					}
+						size: [current, max],
+					},
 				})
-			} else {
+			}
+ else {
 				client.user.setStatus('online')
 				client.user.setActivity({
 					name: current < 2 ? online[3] : `${current} players`,
@@ -90,11 +91,11 @@ const main = async () => {
 					state: `Watching ${online[3]}`,
 					timestamp: {
 						start: activityStart,
-						end: Date.now() + 11000
+						end: Date.now() + 11000,
 					},
 					party: {
-						size: [current, max]
-					}
+						size: [current, max],
+					},
 				})
 			}
 		}, 10000)


### PR DESCRIPTION
Starts off with status=idle and afk=true

When there are no players online, starts custom activity `Waiting for players`

When there are any players online, switches to status=online and afk=false

When there is one player online, starts activity `Watching player_name`

When there are more players online, starts activity `Watching # players`